### PR TITLE
Fix design file display

### DIFF
--- a/resources/views/checkout/form.blade.php
+++ b/resources/views/checkout/form.blade.php
@@ -22,7 +22,11 @@
                 <p><strong>Цена за коробку:</strong> {{ $item['price_per_box'] }} ₽</p>
                 <p><strong>Итого:</strong> {{ $item['total_price'] }} ₽</p>
                 @if (!empty($item['design_file']))
-                    <p><strong>Файл дизайна:</strong> загружен</p>
+                    <p><strong>Файл дизайна:</strong>
+                        <a href="{{ Storage::disk('public')->url($item['design_file']) }}" target="_blank">
+                            {{ basename($item['design_file']) }}
+                        </a>
+                    </p>
                 @endif
 
                 <form method="POST" action="{{ route('checkout.remove', $index) }}" style="margin-top: 10px;">

--- a/resources/views/order/show.blade.php
+++ b/resources/views/order/show.blade.php
@@ -24,6 +24,9 @@
                     прочность: {{ $item->cardboard_strength }},
                     печать: {{ $item->print_type }},
                     {{ number_format($item->price_per_box, 2, ',', ' ') }} ₽/шт
+                    @if ($item->design_file)
+                        , <a href="{{ Storage::disk('public')->url($item->design_file) }}" target="_blank">файл</a>
+                    @endif
                 </li>
             @endforeach
         </ul>


### PR DESCRIPTION
## Summary
- show uploaded design file link on checkout items
- show uploaded design file link in order summary

## Testing
- `composer test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68739e98fc24832b9a2de17a41044151