### PR TITLE
Map labels for order pages

### DIFF
--- a/resources/views/checkout/form.blade.php
+++ b/resources/views/checkout/form.blade.php
@@ -1,5 +1,11 @@
 @extends('layouts.app')
 
+@php
+    $boxNames = \App\Models\BoxType::pluck('name', 'id')->toArray();
+    $colorMap = ['brown' => 'Бурый', 'white' => 'Белый'];
+    $strengthMap = ['econom' => 'Эконом', 'business' => 'Бизнес'];
+@endphp
+
 @section('content')
 <div class="container">
     <h1>Оформление заказа</h1>
@@ -13,11 +19,11 @@
 
         @foreach ($cart as $index => $item)
             <div style="border: 1px solid #ccc; padding: 10px; margin-bottom: 10px;">
-                <p><strong>Тип коробки:</strong> {{ $item['box_type_id'] }}</p>
+                <p><strong>Тип коробки:</strong> {{ $boxNames[$item['box_type_id']] ?? $item['box_type_id'] }}</p>
                 <p><strong>Размер:</strong> {{ $item['length'] }} × {{ $item['width'] }} × {{ $item['height'] }} мм</p>
-                <p><strong>Цвет картона:</strong> {{ $item['color'] }}</p>
+                <p><strong>Цвет картона:</strong> {{ $colorMap[strtolower($item['color'])] ?? $item['color'] }}</p>
                 <p><strong>Толщина:</strong> {{ $item['thickness'] }} мм</p>
-                <p><strong>Прочность:</strong> {{ $item['strength'] }}</p>
+                <p><strong>Прочность:</strong> {{ $strengthMap[strtolower($item['strength'])] ?? $item['strength'] }}</p>
                 <p><strong>Тираж:</strong> {{ $item['quantity'] }}</p>
                 <p><strong>Цена за коробку:</strong> {{ $item['price_per_box'] }} ₽</p>
                 <p><strong>Итого:</strong> {{ $item['total_price'] }} ₽</p>

--- a/resources/views/order/show.blade.php
+++ b/resources/views/order/show.blade.php
@@ -1,5 +1,22 @@
 @extends('layouts.app')
 
+@php
+    $colorMap = ['brown' => 'Бурый', 'white' => 'Белый'];
+    $strengthMap = ['econom' => 'Эконом', 'business' => 'Бизнес'];
+    $printTypeMap = [
+        'none' => 'Без оформления',
+        'print' => 'Печать',
+        'sticker' => 'Наклейка',
+        'wrapper' => 'Обечайка',
+    ];
+    $deliveryMap = [
+        'pickup' => 'Самовывоз',
+        'cdek' => 'СДЭК',
+        'pek' => 'ПЭК',
+        'own' => 'Свой курьер',
+    ];
+@endphp
+
 @section('content')
     <div class="container">
         <h1>Спасибо за заказ!</h1>
@@ -9,7 +26,7 @@
         <p><strong>Email:</strong> {{ $order->customer_email }}</p>
         <p><strong>Телефон:</strong> {{ $order->customer_phone }}</p>
         <p><strong>Адрес доставки:</strong> {{ $order->delivery_address }}</p>
-        <p><strong>Тип доставки:</strong> {{ ucfirst($order->delivery_method) }}</p>
+        <p><strong>Тип доставки:</strong> {{ $deliveryMap[strtolower($order->delivery_method)] ?? $order->delivery_method }}</p>
         <p><strong>Общая стоимость:</strong> {{ number_format($order->total_price, 2, ',', ' ') }} ₽</p>
 
         <h3>Позиции в заказе:</h3>
@@ -20,9 +37,9 @@
                     {{ $item->boxType->name ?? 'N/A' }},
                     {{ $item->length }}×{{ $item->width }}×{{ $item->height }} мм,
                     толщина: {{ $item->cardboard_thickness }} мм,
-                    цвет: {{ $item->cardboard_color }},
-                    прочность: {{ $item->cardboard_strength }},
-                    печать: {{ $item->print_type }},
+                    цвет: {{ $colorMap[strtolower($item->cardboard_color)] ?? $item->cardboard_color }},
+                    прочность: {{ $strengthMap[strtolower($item->cardboard_strength)] ?? $item->cardboard_strength }},
+                    печать: {{ $printTypeMap[$item->print_type] ?? $item->print_type }},
                     {{ number_format($item->price_per_box, 2, ',', ' ') }} ₽/шт
                     @if ($item->design_file)
                         , <a href="{{ Storage::disk('public')->url($item->design_file) }}" target="_blank">файл</a>


### PR DESCRIPTION
## Summary
- move label maps to the top of cart/order views
- make lookups case-insensitive so labels display

## Testing
- `composer test` *(fails: No application encryption key)*

------
https://chatgpt.com/codex/tasks/task_e_6873a433c7fc832bbadd3c1f34e295a1